### PR TITLE
add autoAround

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `auto-around` option for `colSizing` for `Row`.
 
 ## [0.7.2] - 2019-07-26
 ### Changed

--- a/react/Row.tsx
+++ b/react/Row.tsx
@@ -31,6 +31,13 @@ const HORIZONTAL_ALIGN_MAP = {
 enum ColSizing {
   equal = 'equal',
   auto = 'auto',
+  autoAround = 'auto-around',
+}
+
+const autoJustifyTokens: Record<ColSizing, string> = {
+  [ColSizing.auto]: 'justify-between',
+  [ColSizing.autoAround]: 'justify-around',
+  [ColSizing.equal]: '',
 }
 
 export interface Props extends Flex, Gap {
@@ -87,7 +94,9 @@ const Row: StorefrontFunctionComponent<Props> = ({
     )
   }
 
-  const isSizingAuto = colSizing === ColSizing.auto
+  const isSizingAuto =
+    colSizing === ColSizing.auto || colSizing === ColSizing.autoAround
+  const sizingAutoToken = isSizingAuto ? autoJustifyTokens[colSizing!] : ''
 
   const horizontalAlignClass =
     HORIZONTAL_ALIGN_MAP[horizontalAlign || HorizontalAlign.left] ||
@@ -98,9 +107,7 @@ const Row: StorefrontFunctionComponent<Props> = ({
       <div
         className={`${
           breakOnMobile ? 'flex-none flex-ns' : 'flex'
-        } ${margins} ${paddings} ${horizontalAlignClass} ${
-          isSizingAuto ? 'justify-between' : ''
-        } items-stretch w-100`}
+        } ${margins} ${paddings} ${horizontalAlignClass} ${sizingAutoToken} items-stretch w-100`}
       >
         {cols.map((col, i) => {
           const isLast = i === cols.length - 1


### PR DESCRIPTION
Add option `auto-around`for `colSizing` prop in `Row`.

This is used so use can add a `justify-around` instead of a `justify-between` when colSizing is set to automatic.

This way we can have children of row, with auto width and spaced equally.