### PR TITLE
Add missing class to flex col children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CSS handle `flexColChild`.
 
 ## [0.8.0] - 2019-08-30
 ### Added

--- a/README.md
+++ b/README.md
@@ -85,10 +85,11 @@ To use this CSS API, you must add the `styles` builder and create an app styling
 
 Below, we describe the namespaces that are defined by `flex-layout`.
 
-| Class name | Description                |
-| ---------- | -------------------------- |
-| `flexRow`  | The container of a row.    |
-| `flexCol`  | The container of a column. |
+| Class name      | Description                    |
+| --------------- | ------------------------------ |
+| `flexRow`       | The container of a row.        |
+| `flexCol`       | The container of a column.     |
+| `flexColChild`  | The child element of a column. |
 
 ## Rules and recommendations
 

--- a/react/Col.tsx
+++ b/react/Col.tsx
@@ -85,7 +85,10 @@ const Col: StorefrontFunctionComponent<Props> = ({
           return (
             <div
               key={i}
-              className={`pb${rowGap}`}
+            className={`${generateBlockClass(
+                styles.flexColChild,
+                blockClass
+              )}  pb${rowGap}`}
               style={{ height: preventVerticalStretch ? 'auto' : '100%' }}
             >
               {row}

--- a/react/components/FlexLayout.css
+++ b/react/components/FlexLayout.css
@@ -1,3 +1,5 @@
 .flexRow {}
 
 .flexCol {}
+
+.flexColChild {}


### PR DESCRIPTION
#### What did you change? \*
Added a class to children of `.flexCol`
<!--- Describe your changes in detail. -->

#### Why? \*
Without the class name I was forced to use a HTML element selector
<!--- What is the motivation and context for this change? -->

~I'm not adding documentation because flex-layout doesn't have any documentation on the styles API yet. We'll do it in a separate PR.~
EDIT by Breno: done
Linked workspace: https://breno--storecomponents.myvtex.com/st-tropez-shorts/p

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->