### PR TITLE
Use responsive-values for flex-layout props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for [`responsive-values`](https://github.com/vtex-apps/responsive-values) to `Row` and `Col` props.
 
 ## [0.10.1] - 2019-09-19
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,13 +25,13 @@ Notice that you could use _any_ array of blocks as `children`, given that they a
 
 ### Configuration
 
-This props should be edited at your theme's `blocks.json`:
+The props below should be edited at your theme's `blocks.json`. They support [`responsive-values`](https://github.com/vtex-apps/responsive-values), so you can define to the same prop different values based on the screen size.
 
 #### flex-layout.row
 
 | Prop name                  | Type                  | Description                                                                                                   | Default value |
 | -------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------- | ------------- |
-| `blockClass`               | `String`              | Unique class name to be appended to block container class                                                     | `""`          |
+| `blockClass`               | `String`              | Unique class name to be appended to block container class                                                     | `""`          |
 | `fullWidth`                | `Boolean`             | Whether or not the component should ocuppy all the available width from its parent                            | `false`       |
 | `marginTop`                | `0...10`  | A `number` or `string` magnitude for the `mt` Tachyons token to be applied to this row.                       | `undefined`   |
 | `marginBottom`             | `0...10`  | A `number` or `string` magnitude for the `mb` Tachyons token to be applied to this row.                       | `undefined`   |
@@ -49,7 +49,7 @@ This props should be edited at your theme's `blocks.json`:
 
 | Prop name                | Type                 | Description                                                                                                                | Default value |
 | ------------------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `blockClass`             | `String`             | Unique class name to be appended to block container class                                                                  | `""`          |
+| `blockClass`             | `String`             | Unique class name to be appended to block container class                                                                  | `""`          |
 | `rowGap`                 | `0...10` | A `number` or `string` magnitude for the `pb` Tachyons token to be applied to rows inside of the flex-column.              | `undefined`   |
 | `marginLeft`             | `0...10` | A `number` or `string` magnitude for the `ml` Tachyons token to be applied to this row.                                    | `undefined`   |
 | `marginRight`            | `0...10` | A `number` or `string` magnitude for the `mr` Tachyons token to be applied to this column.                                 | `undefined`   |

--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "vtex.store-components": "3.x",
-    "vtex.device-detector": "0.x"
+    "vtex.device-detector": "0.x",
+    "vtex.responsive-values": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/Col.tsx
+++ b/react/Col.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useResponsiveValues } from 'vtex.responsive-values'
 import { defineMessages } from 'react-intl'
 
 import {
@@ -64,17 +65,21 @@ const parseHorizontalAlign = (input?: string) => {
 const Col: StorefrontFunctionComponent<Props> = ({
   children,
   blockClass,
-  colGap,
-  rowGap,
-  marginLeft,
-  marginRight,
-  paddingLeft,
-  paddingRight,
-  grow,
-  preventVerticalStretch,
-  verticalAlign,
-  horizontalAlign,
+  ...props
 }) => {
+  const {
+    colGap,
+    rowGap,
+    marginLeft,
+    marginRight,
+    paddingLeft,
+    paddingRight,
+    grow,
+    preventVerticalStretch,
+    verticalAlign,
+    horizontalAlign,
+  } = useResponsiveValues(props) as Props
+
   const context = useFlexLayoutContext()
 
   const gaps = parseTachyonsGroup({

--- a/react/Col.tsx
+++ b/react/Col.tsx
@@ -64,10 +64,10 @@ const parseHorizontalAlign = (input?: string) => {
 
 const Col: StorefrontFunctionComponent<Props> = ({
   children,
-  blockClass,
   ...props
 }) => {
   const {
+    blockClass,
     colGap,
     rowGap,
     marginLeft,

--- a/react/FlexLayout.tsx
+++ b/react/FlexLayout.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Container from 'vtex.store-components/Container'
+import { useResponsiveValues } from 'vtex.responsive-values'
 import { defineMessages } from 'react-intl'
 
 import {
@@ -16,10 +17,11 @@ interface Props extends RowProps {
 }
 
 const FlexLayout: StorefrontFunctionComponent<Props & BlockClass> = props => {
-  const { fullWidth, blockClass } = props
+  const responsiveProps = useResponsiveValues(props) as Props
+  const { fullWidth, blockClass } = responsiveProps
   const context = useFlexLayoutContext()
 
-  const content = <Row {...props} />
+  const content = <Row {...responsiveProps} />
 
   const baseClassNames = generateBlockClass(styles.flexRow, blockClass)
   const isTopLevel = context.parent === FlexLayoutTypes.NONE

--- a/react/Row.tsx
+++ b/react/Row.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { useResponsiveValues } from 'vtex.responsive-values'
 import {
   FlexLayoutTypes,
   FlexLayoutContextProvider,
@@ -58,22 +57,21 @@ export interface Props extends Flex, Gap {
   colJustify?: ColJustify
 }
 
-const Row: StorefrontFunctionComponent<Props> = ({ children, ...props }) => {
-  const {
-    colGap,
-    rowGap,
-    marginTop,
-    marginBottom,
-    paddingTop,
-    paddingBottom,
-    preserveLayoutOnMobile,
-    preventHorizontalStretch,
-    preventVerticalStretch,
-    horizontalAlign,
-    colSizing,
-    colJustify = ColJustify.between,
-  } = useResponsiveValues(props) as Props
-
+const Row: StorefrontFunctionComponent<Props> = ({
+  children,
+  colGap,
+  rowGap,
+  marginTop,
+  marginBottom,
+  paddingTop,
+  paddingBottom,
+  preserveLayoutOnMobile,
+  preventHorizontalStretch,
+  preventVerticalStretch,
+  horizontalAlign,
+  colSizing,
+  colJustify = ColJustify.between,
+}) => {
   const context = useFlexLayoutContext()
 
   const gaps = parseTachyonsGroup({

--- a/react/Row.tsx
+++ b/react/Row.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useResponsiveValues } from 'vtex.responsive-values'
 import {
   FlexLayoutTypes,
   FlexLayoutContextProvider,
@@ -57,21 +58,22 @@ export interface Props extends Flex, Gap {
   colJustify?: ColJustify
 }
 
-const Row: StorefrontFunctionComponent<Props> = ({
-  children,
-  colGap,
-  rowGap,
-  marginTop,
-  marginBottom,
-  paddingTop,
-  paddingBottom,
-  preserveLayoutOnMobile,
-  preventHorizontalStretch,
-  preventVerticalStretch,
-  horizontalAlign,
-  colSizing,
-  colJustify = ColJustify.between,
-}) => {
+const Row: StorefrontFunctionComponent<Props> = ({ children, ...props }) => {
+  const {
+    colGap,
+    rowGap,
+    marginTop,
+    marginBottom,
+    paddingTop,
+    paddingBottom,
+    preserveLayoutOnMobile,
+    preventHorizontalStretch,
+    preventVerticalStretch,
+    horizontalAlign,
+    colSizing,
+    colJustify = ColJustify.between,
+  } = useResponsiveValues(props) as Props
+
   const context = useFlexLayoutContext()
 
   const gaps = parseTachyonsGroup({

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -1,5 +1,5 @@
 import { FunctionComponent } from 'react'
-import { TachyonsScaleInput } from '../hooks/tachyons'
+import { TachyonsScaleInput } from '../modules/valuesParser'
 
 declare global {
   interface StorefrontFunctionComponent<P = {}> extends FunctionComponent<P> {


### PR DESCRIPTION
#### What did you change? \*

This allows one to use [`responsive-values`](https://github.com/vtex-apps/responsive-values) to define `Row` and `Col` props.

#### Why? \*

Oftentimes a `flex-layout` container needs to have different prop values for different screen sizes, one of the most common scenarios being spacing props. Currently, in order to do that we not only need to define one different block for each size but also need to wrap them in another container responsible for dealing with the responsiveness. 
This PR makes this case much easier to deal with by simply allowing the user to specify prop values for each screen size in a single `flex-layout` block.

#### How to test it? \*

Go [here](https://responsive--storecomponents.myvtex.com/about-us). This workspace has `store-theme` linked with the following change in `store/blocks/about-us.json`:
```json
"flex-layout.row#about-us": {
  "children": [
    "image#mobile-phone",
    "flex-layout.col#text-about-us"
  ],
  "props": {
    "marginTop": {
      "mobile": 11,
      "desktop": 0
    }
  }
},
```
Verify the `marginTop` prop behaves as expected.

#### Related to / Depends on?

This PR depends on https://github.com/vtex-apps/responsive-values/pull/2 and **cannot be merged** before it.

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
