### PR TITLE
Feature/new css handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `flexRowContent` CSS handle.
 
 ## [0.13.1] - 2019-12-03
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,20 +22,20 @@ The props below support [`responsive-values`](https://github.com/vtex-apps/respo
 | Prop name                  | Type                              | Description                                                                                                             | Default value |
 | -------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------- |
 | `blockClass`               | `String`                          | Block container class. This prop’s set value functions as a block identifier for CSS customizations. (                  | `""`          |
-| `fullWidth`                | `Boolean`                         | Whether or not the component should ocuppy all the available width from its parent.                                     | `false`       |
-| `marginTop`                | `0...10`                          | A `number` or `string` magnitude for the `mt` Tachyons token to be applied to the row.                                  | `undefined`   |
-| `marginBottom`             | `0...10`                          | A `number` or `string` magnitude for the `mb` Tachyons token to be applied to the row.                                  | `undefined`   |
-| `paddingTop`               | `0...10`                          | A `number` or `string` magnitude for the `pt` Tachyons token to be applied to the row.                                  | `undefined`   |
-| `paddingBottom`            | `0...10`                          | A `number` or `string` magnitude for the `pb` Tachyons token to be applied to the row.                                  | `undefined`   |
-| `border`                   | `String \| String[]`              | An array to define in which sides of the row a border should be applied to (`top`, `right`, `bottom`, `left` or `all`). | `undefined`   |
-| `borderWidth`              | `0...5`                           | A `number` or `string` magnitude for the `bw` Tachyons token to be applied to the row.                                  | `undefined`   |
 | `borderColor`              | `String`                          | The color of the border.                                                                                                | `undefined`   |
+| `borderWidth`              | `0...5`                           | A `number` or `string` magnitude for the `bw` Tachyons token to be applied to the row.                                  | `undefined`   |
+| `border`                   | `String \| String[]`              | An array to define in which sides of the row a border should be applied to (`top`, `right`, `bottom`, `left` or `all`). | `undefined`   |
+| `colGap`                   | `0...10`                          | A `number` or `string` magnitude for the `pr` Tachyons token to be applied to columns inside of the `flex-layout.row`.  | `undefined`   |
+| `colSizing`                | `equal`&#124;`auto`               | Controls the width of the columns inside the `flex-layout.row`.                                                         | `equal`       |
+| `fullWidth`                | `Boolean`                         | Whether or not the component should ocuppy all the available width from its parent.                                     | `false`       |
+| `horizontalAlign`          | `left`&#124;`right`&#124;`center` | Controls horizontal alignment for the items inside the `flex-layout.row`.                                               | `left`        |
+| `marginBottom`             | `0...10`                          | A `number` or `string` magnitude for the `mb` Tachyons token to be applied to the row.                                  | `undefined`   |
+| `marginTop`                | `0...10`                          | A `number` or `string` magnitude for the `mt` Tachyons token to be applied to the row.                                  | `undefined`   |
+| `paddingBottom`            | `0...10`                          | A `number` or `string` magnitude for the `pb` Tachyons token to be applied to the row.                                  | `undefined`   |
+| `paddingTop`               | `0...10`                          | A `number` or `string` magnitude for the `pt` Tachyons token to be applied to the row.                                  | `undefined`   |
 | `preserveLayoutOnMobile`   | `Boolean`                         | Whether or not the `flex-layout.row` should break into a column layout on mobile.                                       | `false`       |
 | `preventHorizontalStretch` | `Boolean`                         | Prevents the row from stretching horizontally to fill its parent width.                                                 | `false`       |
 | `preventVerticalStretch`   | `Boolean`                         | Prevents the row from stretching vertically to fill its parent height with `items-stretch` token.                       | `false`       |
-| `horizontalAlign`          | `left`&#124;`right`&#124;`center` | Controls horizontal alignment for the items inside the `flex-layout.row`.                                               | `left`        |
-| `colSizing`                | `equal`&#124;`auto`               | Controls the width of the columns inside the `flex-layout.row`.                                                         | `equal`       |
-| `colGap`                   | `0...10`                          | A `number` or `string` magnitude for the `pr` Tachyons token to be applied to columns inside of the `flex-layout.row`.  | `undefined`   |
 | `rowGap`                   | `0...10`                          | A `number` or `string` magnitude for the `pb` Tachyons token to be applied to columns inside of the `flex-layout.row`.  | `undefined`   |
 
 ### `flex-layout.col`
@@ -43,18 +43,18 @@ The props below support [`responsive-values`](https://github.com/vtex-apps/respo
 | Prop name                | Type                              | Description                                                                                                                | Default value |
 | ------------------------ | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------- |
 | `blockClass`             | `String`                          | Block container class. This prop’s set value functions as a block identifier for CSS customizations                        | `""`          |
-| `rowGap`                 | `0...10`                          | A `number` or `string` magnitude for the `pb` Tachyons token to be applied to rows inside of the `flex-layout.col`.        | `undefined`   |
+| `borderColor`            | `String`                          | The color of the border.                                                                                                   | `undefined`   |
+| `borderWidth`            | `0...5`                           | A `number` or `string` magnitude for the `bw` Tachyons token to be applied to the column.                                  | `undefined`   |
+| `border`                 | `String \| String[]`              | An array to define in which sides of the row a border should be applied to (`top`, `right`, `bottom`, `left` or `all`).    | `undefined`   |
+| `horizontalAlign`        | `left`&#124;`right`&#124;`center` | Controls horizontal alignment for the items inside the `flex-layout.col`.                                                  | `left`        |
 | `marginLeft`             | `0...10`                          | A `number` or `string` magnitude for the `ml` Tachyons token to be applied to the column.                                  | `undefined`   |
 | `marginRight`            | `0...10`                          | A `number` or `string` magnitude for the `mr` Tachyons token to be applied to the column.                                  | `undefined`   |
 | `paddingLeft`            | `0...10`                          | A `number` or `string` magnitude for the `pl` Tachyons token to be applied to the column.                                  | `undefined`   |
 | `paddingRight`           | `0...10`                          | A `number` or `string` magnitude for the `pr` Tachyons token to be applied to the column.                                  | `undefined`   |
-| `border`                 | `String \| String[]`              | An array to define in which sides of the row a border should be applied to (`top`, `right`, `bottom`, `left` or `all`).    | `undefined`   |
-| `borderWidth`            | `0...5`                           | A `number` or `string` magnitude for the `bw` Tachyons token to be applied to the column.                                  | `undefined`   |
-| `borderColor`            | `String`                          | The color of the border.                                                                                                   | `undefined`   |
-| `horizontalAlign`        | `left`&#124;`right`&#124;`center` | Controls horizontal alignment for the items inside the `flex-layout.col`.                                                  | `left`        |
+| `preventVerticalStretch` | `Boolean`                         | Prevents the row from stretching vertically to fill its parent height with `height: 100%`, using `height: "auto"` instead. | `false`       |
+| `rowGap`                 | `0...10`                          | A `number` or `string` magnitude for the `pb` Tachyons token to be applied to rows inside of the `flex-layout.col`.        | `undefined`   |
 | `verticalAlign`          | `top`&#124;`middle`&#124;`bottom` | Controls vertical alignment for the items inside the `flex-layout.col`.                                                    | `top`         |
 | `width`                  | `"0...100%"`&#124;`"grow"`        | Sets the width of the column. Accepts either a percentage or `"grow"`.                                                     | `undefined`   |
-| `preventVerticalStretch` | `Boolean`                         | Prevents the row from stretching vertically to fill its parent height with `height: 100%`, using `height: "auto"` instead. | `false`       |
 
 ## Modus Operandi
 
@@ -71,7 +71,7 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 
 | CSS Handles      |
 | ---------------- |
-| `flexRow`        |
-| `flexRowContent` |
-| `flexCol`        |
 | `flexColChild`   |
+| `flexCol`        |
+| `flexRowContent` |
+| `flexRow`        |

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@
 Flex Layout is a **layout structure** built within VTEX IO store framework. It allows the construction of complex custom layouts using the concept of **rows** and **columns**, setting the desired structure and positioning of blocks in a given page.
 
 ![Screen Shot 2019-08-21 at 4 05 19 PM](https://user-images.githubusercontent.com/27777263/63467270-736abb80-c43b-11e9-8a7b-dfe8f218f081.png)
-*Example of a page layout built using Flex Layout, following the one row with two columns model*
+_Example of a page layout built using Flex Layout, following the one row with two columns model_
 
 ## Configuration
 
@@ -19,42 +19,42 @@ The props below support [`responsive-values`](https://github.com/vtex-apps/respo
 
 ### `flex-layout.row`
 
-| Prop name                  | Type                  | Description                                                                                                   | Default value |
-| -------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------- | ------------- |
-| `blockClass`               | `String`              | Block container class. This prop’s set value functions as a block identifier for CSS customizations. (                                                   | `""`          |
-| `fullWidth`                | `Boolean`             | Whether or not the component should ocuppy all the available width from its parent.                           | `false`       |
-| `marginTop`                | `0...10`  | A `number` or `string` magnitude for the `mt` Tachyons token to be applied to the row.                       | `undefined`   |
-| `marginBottom`             | `0...10`  | A `number` or `string` magnitude for the `mb` Tachyons token to be applied to the row.                       | `undefined`   |
-| `paddingTop`               | `0...10`  | A `number` or `string` magnitude for the `pt` Tachyons token to be applied to the row.                       | `undefined`   |
-| `paddingBottom`            | `0...10`  | A `number` or `string` magnitude for the `pb` Tachyons token to be applied to the row.                       | `undefined`   |
-| `border`                   | `String \| String[]`            | An array to define in which sides of the row a border should be applied to (`top`, `right`, `bottom`, `left` or `all`). | `undefined`   |
-| `borderWidth`              | `0...5`               | A `number` or `string` magnitude for the `bw` Tachyons token to be applied to the row.                        | `undefined`   |
-| `borderColor`              | `String`              | The color of the border.                                                                                       | `undefined`   |
-| `preserveLayoutOnMobile`   | `Boolean`             | Whether or not the `flex-layout.row` should break into a column layout on mobile.                                      | `false`       |
-| `preventHorizontalStretch` | `Boolean`             | Prevents the row from stretching horizontally to fill its parent width.                                       | `false`       |
-| `preventVerticalStretch`   | `Boolean`             | Prevents the row from stretching vertically to fill its parent height with `items-stretch` token.             | `false`       |
-| `horizontalAlign`          | `left`&#124;`right`&#124;`center` | Controls horizontal alignment for the items inside the `flex-layout.row`.                                              | `left`        |
-| `colSizing`                | `equal`&#124;`auto`       | Controls the width of the columns inside the `flex-layout.row`.                                                        | `equal`       |
-| `colGap`                   | `0...10`  | A `number` or `string` magnitude for the `pr` Tachyons token to be applied to columns inside of the `flex-layout.row`. | `undefined`   |
-| `rowGap`                   | `0...10`  | A `number` or `string` magnitude for the `pb` Tachyons token to be applied to columns inside of the `flex-layout.row`. | `undefined`   |
+| Prop name                  | Type                              | Description                                                                                                             | Default value |
+| -------------------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `blockClass`               | `String`                          | Block container class. This prop’s set value functions as a block identifier for CSS customizations. (                  | `""`          |
+| `fullWidth`                | `Boolean`                         | Whether or not the component should ocuppy all the available width from its parent.                                     | `false`       |
+| `marginTop`                | `0...10`                          | A `number` or `string` magnitude for the `mt` Tachyons token to be applied to the row.                                  | `undefined`   |
+| `marginBottom`             | `0...10`                          | A `number` or `string` magnitude for the `mb` Tachyons token to be applied to the row.                                  | `undefined`   |
+| `paddingTop`               | `0...10`                          | A `number` or `string` magnitude for the `pt` Tachyons token to be applied to the row.                                  | `undefined`   |
+| `paddingBottom`            | `0...10`                          | A `number` or `string` magnitude for the `pb` Tachyons token to be applied to the row.                                  | `undefined`   |
+| `border`                   | `String \| String[]`              | An array to define in which sides of the row a border should be applied to (`top`, `right`, `bottom`, `left` or `all`). | `undefined`   |
+| `borderWidth`              | `0...5`                           | A `number` or `string` magnitude for the `bw` Tachyons token to be applied to the row.                                  | `undefined`   |
+| `borderColor`              | `String`                          | The color of the border.                                                                                                | `undefined`   |
+| `preserveLayoutOnMobile`   | `Boolean`                         | Whether or not the `flex-layout.row` should break into a column layout on mobile.                                       | `false`       |
+| `preventHorizontalStretch` | `Boolean`                         | Prevents the row from stretching horizontally to fill its parent width.                                                 | `false`       |
+| `preventVerticalStretch`   | `Boolean`                         | Prevents the row from stretching vertically to fill its parent height with `items-stretch` token.                       | `false`       |
+| `horizontalAlign`          | `left`&#124;`right`&#124;`center` | Controls horizontal alignment for the items inside the `flex-layout.row`.                                               | `left`        |
+| `colSizing`                | `equal`&#124;`auto`               | Controls the width of the columns inside the `flex-layout.row`.                                                         | `equal`       |
+| `colGap`                   | `0...10`                          | A `number` or `string` magnitude for the `pr` Tachyons token to be applied to columns inside of the `flex-layout.row`.  | `undefined`   |
+| `rowGap`                   | `0...10`                          | A `number` or `string` magnitude for the `pb` Tachyons token to be applied to columns inside of the `flex-layout.row`.  | `undefined`   |
 
 ### `flex-layout.col`
 
-| Prop name                | Type                 | Description                                                                                                                | Default value |
-| ------------------------ | -------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `blockClass`             | `String`             | Block container class. This prop’s set value functions as a block identifier for CSS customizations                                                               | `""`          |
-| `rowGap`                 | `0...10` | A `number` or `string` magnitude for the `pb` Tachyons token to be applied to rows inside of the `flex-layout.col`.              | `undefined`   |
-| `marginLeft`             | `0...10` | A `number` or `string` magnitude for the `ml` Tachyons token to be applied to the column.                                    | `undefined`   |
-| `marginRight`            | `0...10` | A `number` or `string` magnitude for the `mr` Tachyons token to be applied to the column.                                 | `undefined`   |
-| `paddingLeft`            | `0...10` | A `number` or `string` magnitude for the `pl` Tachyons token to be applied to the column.                                 | `undefined`   |
-| `paddingRight`           | `0...10` | A `number` or `string` magnitude for the `pr` Tachyons token to be applied to the column.                                 | `undefined`   |
-| `border`                 | `String \| String[]`            | An array to define in which sides of the row a border should be applied to (`top`, `right`, `bottom`, `left` or `all`).    | `undefined`   |
-| `borderWidth`            | `0...5`               | A `number` or `string` magnitude for the `bw` Tachyons token to be applied to the column.                           | `undefined`   |
-| `borderColor`            | `String`              | The color of the border.                                                                                             | `undefined`   |
-| `horizontalAlign`        | `left`&#124;`right`&#124;`center` | Controls horizontal alignment for the items inside the `flex-layout.col`.                                              | `left`        |
-| `verticalAlign`          | `top`&#124;`middle`&#124;`bottom` | Controls vertical alignment for the items inside the `flex-layout.col`.                                              | `top`        |
-| `width`                  | `"0...100%"`&#124;`"grow"` | Sets the width of the column. Accepts either a percentage or `"grow"`. | `undefined` |
-| `preventVerticalStretch` | `Boolean`            | Prevents the row from stretching vertically to fill its parent height with `height: 100%`, using `height: "auto"` instead. | `false`       |
+| Prop name                | Type                              | Description                                                                                                                | Default value |
+| ------------------------ | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `blockClass`             | `String`                          | Block container class. This prop’s set value functions as a block identifier for CSS customizations                        | `""`          |
+| `rowGap`                 | `0...10`                          | A `number` or `string` magnitude for the `pb` Tachyons token to be applied to rows inside of the `flex-layout.col`.        | `undefined`   |
+| `marginLeft`             | `0...10`                          | A `number` or `string` magnitude for the `ml` Tachyons token to be applied to the column.                                  | `undefined`   |
+| `marginRight`            | `0...10`                          | A `number` or `string` magnitude for the `mr` Tachyons token to be applied to the column.                                  | `undefined`   |
+| `paddingLeft`            | `0...10`                          | A `number` or `string` magnitude for the `pl` Tachyons token to be applied to the column.                                  | `undefined`   |
+| `paddingRight`           | `0...10`                          | A `number` or `string` magnitude for the `pr` Tachyons token to be applied to the column.                                  | `undefined`   |
+| `border`                 | `String \| String[]`              | An array to define in which sides of the row a border should be applied to (`top`, `right`, `bottom`, `left` or `all`).    | `undefined`   |
+| `borderWidth`            | `0...5`                           | A `number` or `string` magnitude for the `bw` Tachyons token to be applied to the column.                                  | `undefined`   |
+| `borderColor`            | `String`                          | The color of the border.                                                                                                   | `undefined`   |
+| `horizontalAlign`        | `left`&#124;`right`&#124;`center` | Controls horizontal alignment for the items inside the `flex-layout.col`.                                                  | `left`        |
+| `verticalAlign`          | `top`&#124;`middle`&#124;`bottom` | Controls vertical alignment for the items inside the `flex-layout.col`.                                                    | `top`         |
+| `width`                  | `"0...100%"`&#124;`"grow"`        | Sets the width of the column. Accepts either a percentage or `"grow"`.                                                     | `undefined`   |
+| `preventVerticalStretch` | `Boolean`                         | Prevents the row from stretching vertically to fill its parent height with `height: 100%`, using `height: "auto"` instead. | `false`       |
 
 ## Modus Operandi
 
@@ -69,8 +69,9 @@ To better understand Flex Layout's practical operation, you can access the recip
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
 
-| CSS Handles     |
-| --------------- | 
-| `flexRow`       | 
-| `flexCol`       | 
-| `flexColChild`  | 
+| CSS Handles      |
+| ---------------- |
+| `flexRow`        |
+| `flexRowContent` |
+| `flexCol`        |
+| `flexColChild`   |

--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "vtex.store-components": "3.x",
     "vtex.device-detector": "0.x",
-    "vtex.responsive-values": "0.x"
+    "vtex.responsive-values": "0.x",
+    "vtex.css-handles": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/Col.tsx
+++ b/react/Col.tsx
@@ -1,16 +1,13 @@
 import React from 'react'
-import { useResponsiveValues } from 'vtex.responsive-values'
 import { defineMessages } from 'react-intl'
+import { useResponsiveValues } from 'vtex.responsive-values'
+import { useCssHandles } from 'vtex.css-handles'
 
 import {
   FlexLayoutTypes,
   useFlexLayoutContext,
   FlexLayoutContextProvider,
 } from './components/FlexLayoutContext'
-import { generateBlockClass } from '@vtex/css-handles'
-
-import styles from './components/FlexLayout.css'
-
 import {
   TachyonsScaleInput,
   parseTachyonsGroup,
@@ -63,9 +60,10 @@ const parseHorizontalAlign = (input?: string) => {
   return ''
 }
 
+const CSS_HANDLES = ['flexCol', 'flexColChild'] as const
+
 const Col: StorefrontFunctionComponent<Props> = ({ children, ...props }) => {
   const {
-    blockClass,
     colGap,
     rowGap,
     marginLeft,
@@ -82,6 +80,7 @@ const Col: StorefrontFunctionComponent<Props> = ({ children, ...props }) => {
   } = useResponsiveValues(props) as Props
 
   const context = useFlexLayoutContext()
+  const handles = useCssHandles(CSS_HANDLES)
 
   const gaps = parseTachyonsGroup({
     colGap: colGap != null ? colGap : context.colGap,
@@ -125,7 +124,7 @@ const Col: StorefrontFunctionComponent<Props> = ({ children, ...props }) => {
   return (
     <FlexLayoutContextProvider parent={FlexLayoutTypes.COL} {...gaps}>
       <div
-        className={`${generateBlockClass(styles.flexCol, blockClass)} ${
+        className={`${handles.flexCol} ${
           grow ? 'flex-grow-1' : ''
         } ${margins} ${paddings} ${borders} ${vertical} ${horizontal} flex flex-column h-100 w-100`}
       >
@@ -136,10 +135,7 @@ const Col: StorefrontFunctionComponent<Props> = ({ children, ...props }) => {
           return (
             <div
               key={i}
-              className={`${generateBlockClass(
-                styles.flexColChild,
-                blockClass
-              )} pb${rowGap}`}
+              className={`${handles.flexColChild} pb${rowGap}`}
               style={{
                 height:
                   preventVerticalStretch || verticalAlign ? 'auto' : '100%',

--- a/react/FlexLayout.tsx
+++ b/react/FlexLayout.tsx
@@ -1,29 +1,29 @@
 import React from 'react'
+import { defineMessages } from 'react-intl'
+import { useCssHandles } from 'vtex.css-handles'
 import Container from 'vtex.store-components/Container'
 import { useResponsiveValues } from 'vtex.responsive-values'
-import { defineMessages } from 'react-intl'
 
 import {
   FlexLayoutTypes,
   useFlexLayoutContext,
 } from './components/FlexLayoutContext'
 import Row, { Props as RowProps } from './Row'
-import { generateBlockClass, BlockClass } from '@vtex/css-handles'
-
-import styles from './components/FlexLayout.css'
 
 interface Props extends RowProps {
   fullWidth?: boolean
 }
 
-const FlexLayout: StorefrontFunctionComponent<Props & BlockClass> = props => {
+const CSS_HANDLES = ['flexRow'] as const
+
+const FlexLayout: StorefrontFunctionComponent<Props> = props => {
   const responsiveProps = useResponsiveValues(props) as Props
-  const { fullWidth, blockClass } = responsiveProps
+  const { fullWidth } = responsiveProps
   const context = useFlexLayoutContext()
+  const handles = useCssHandles(CSS_HANDLES)
 
   const content = <Row {...responsiveProps} />
 
-  const baseClassNames = generateBlockClass(styles.flexRow, blockClass)
   const isTopLevel = context.parent === FlexLayoutTypes.NONE
 
   if (fullWidth && !isTopLevel) {
@@ -33,11 +33,11 @@ const FlexLayout: StorefrontFunctionComponent<Props & BlockClass> = props => {
   }
 
   if (fullWidth || !isTopLevel) {
-    return <div className={baseClassNames}>{content}</div>
+    return <div className={handles.flexRow}>{content}</div>
   }
 
   return (
-    <div className={baseClassNames}>
+    <div className={handles.flexRow}>
       <Container>{content}</Container>
     </div>
   )

--- a/react/Row.css
+++ b/react/Row.css
@@ -11,5 +11,3 @@
 .stretchChildrenWidth > *:not(img) {
   width: 100%;
 }
-
-.flexRowContent {}

--- a/react/Row.css
+++ b/react/Row.css
@@ -11,3 +11,5 @@
 .stretchChildrenWidth > *:not(img) {
   width: 100%;
 }
+
+.flexRowContent {}

--- a/react/Row.tsx
+++ b/react/Row.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { generateBlockClass } from '@vtex/css-handles'
 import { defineMessages } from 'react-intl'
+import { useCssHandles } from 'vtex.css-handles'
 
 import {
   FlexLayoutTypes,
@@ -46,6 +46,8 @@ const JustifyValues = {
   [ColJustify.around]: 'justify-around',
 }
 
+const CSS_HANDLES = ['flexRowContent'] as const
+
 export interface Props extends Flex, Gap, Border {
   blockClass?: string
   marginTop: TachyonsScaleInput
@@ -80,6 +82,7 @@ const Row: StorefrontFunctionComponent<Props> = ({
   colJustify = ColJustify.between,
 }) => {
   const context = useFlexLayoutContext()
+  const handles = useCssHandles(CSS_HANDLES)
 
   const gaps = parseTachyonsGroup({
     colGap: colGap != null ? colGap : context.colGap,
@@ -128,10 +131,7 @@ const Row: StorefrontFunctionComponent<Props> = ({
           breakOnMobile ? 'flex-none flex-ns' : 'flex'
         } ${margins} ${paddings} ${borders} ${horizontalAlignClass} ${
           isSizingAuto ? justifyToken : ''
-        } ${generateBlockClass(
-          styles.flexRowContent,
-          blockClass
-        )} items-stretch w-100`}
+        } ${handles.flexRowContent} items-stretch w-100`}
       >
         {cols.map((col, i) => {
           const isLast = i === cols.length - 1

--- a/react/Row.tsx
+++ b/react/Row.tsx
@@ -78,7 +78,6 @@ const Row: StorefrontFunctionComponent<Props> = ({
   preventVerticalStretch,
   horizontalAlign,
   colSizing,
-  blockClass,
   colJustify = ColJustify.between,
 }) => {
   const context = useFlexLayoutContext()

--- a/react/Row.tsx
+++ b/react/Row.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
+import { generateBlockClass } from '@vtex/css-handles'
+import { defineMessages } from 'react-intl'
+
 import {
   FlexLayoutTypes,
   FlexLayoutContextProvider,
   useFlexLayoutContext,
 } from './components/FlexLayoutContext'
-import { defineMessages } from 'react-intl'
 
 import { useResponsiveWidth } from './hooks/responsiveWidth'
 import {
@@ -74,6 +76,7 @@ const Row: StorefrontFunctionComponent<Props> = ({
   preventVerticalStretch,
   horizontalAlign,
   colSizing,
+  blockClass,
   colJustify = ColJustify.between,
 }) => {
   const context = useFlexLayoutContext()
@@ -125,7 +128,10 @@ const Row: StorefrontFunctionComponent<Props> = ({
           breakOnMobile ? 'flex-none flex-ns' : 'flex'
         } ${margins} ${paddings} ${borders} ${horizontalAlignClass} ${
           isSizingAuto ? justifyToken : ''
-        } items-stretch w-100`}
+        } ${generateBlockClass(
+          styles.flexRowContent,
+          blockClass
+        )} items-stretch w-100`}
       >
         {cols.map((col, i) => {
           const isLast = i === cols.length - 1

--- a/react/components/FlexLayout.css
+++ b/react/components/FlexLayout.css
@@ -1,5 +1,0 @@
-.flexRow {}
-
-.flexCol {}
-
-.flexColChild {}

--- a/react/package.json
+++ b/react/package.json
@@ -16,7 +16,7 @@
     "eslint-config-vtex-react": "^5.0.1",
     "prettier": "^1.18.2",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "3.5.2"
+    "typescript": "3.7.3"
   },
   "resolutions": {
     "@types/graphql": "14.0.7"

--- a/react/typings/vtex.css-handles.d.ts
+++ b/react/typings/vtex.css-handles.d.ts
@@ -1,0 +1,1 @@
+declare module 'vtex.css-handles'

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5168,10 +5168,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 typescript@^3.3.3333:
   version "3.6.3"


### PR DESCRIPTION
#### What did you change?

Added a new `flexRowContent` CSS handle into `Row.tsx`.

#### Why?

To enable further customization.

Should solve this: https://app.clubhouse.io/vtex/story/29386/add-missing-css-handles-in-flex-layout

#### How to test it?

Inspect this workspace: https://flexlayout--storecomponents.myvtex.com/ .

![Screen Shot 2020-01-23 at 15 12 06](https://user-images.githubusercontent.com/27777263/73011766-ae5e8a00-3df3-11ea-9941-f761e66a2534.png)
![Screen Shot 2020-01-23 at 15 12 20](https://user-images.githubusercontent.com/27777263/73011767-ae5e8a00-3df3-11ea-8e69-9d563fc65ff7.png)

- [Boticário](https://flexlayouttest--boticario.myvtex.com/)
- [TBB](https://flexlayouttest--tbb.myvtex.com/)


#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
