### PR TITLE
Add item wrapper class in flex-layout.row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `flexRowItemWrapper` CSS handle.
 
 ## [0.14.0] - 2020-01-27
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -75,3 +75,4 @@ In order to apply CSS customizations in this and other blocks, follow the instru
 | `flexCol`        |
 | `flexRowContent` |
 | `flexRow`        |
+| `flexRowItemWrapper` |

--- a/react/Row.tsx
+++ b/react/Row.tsx
@@ -46,7 +46,7 @@ const JustifyValues = {
   [ColJustify.around]: 'justify-around',
 }
 
-const CSS_HANDLES = ['flexRowContent'] as const
+const CSS_HANDLES = ['flexRowContent', 'flexRowItemWrapper'] as const
 
 export interface Props extends Flex, Gap, Border {
   blockClass?: string
@@ -147,7 +147,9 @@ const Row: StorefrontFunctionComponent<Props> = ({
                   : `pr${colGap}`
               } ${preventVerticalStretch ? '' : 'items-stretch'} ${
                 preventHorizontalStretch ? '' : styles.stretchChildrenWidth
-              } ${col.width === 'grow' ? 'flex-grow-1' : ''} flex`}
+              } ${col.width === 'grow' ? 'flex-grow-1' : ''} flex ${
+                handles.flexRowItemWrapper
+              }`}
               style={{
                 width:
                   preventHorizontalStretch ||


### PR DESCRIPTION
#### What did you change? \*
Added the `flexRowItemWrapper` class.

#### Why? \*
I needed to customize this wrapper in order to centralize a container in the page using `flex-layout`.

#### How to test it? \*
You can see the changes in this [workspace](https://lucas--checkoutio.myvtex.com/checkout/identification).

#### Types of changes \*

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical improvements
  <!--- * Required -->
