### PR TITLE
Feature/clear warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Lots of obsolete warnings.
 
 ## [0.15.0] - 2020-05-04
 ### Added

--- a/react/Col.tsx
+++ b/react/Col.tsx
@@ -103,16 +103,7 @@ const Col: StorefrontFunctionComponent<Props> = ({ children, ...props }) => {
     borderColor,
   })
 
-  if (context.parent === FlexLayoutTypes.COL) {
-    console.warn(
-      'A `flex-layout.col` is being inserted directly into another `flex-layout.col`. This might might have unpredicted behaviour.'
-    )
-  }
-
   if (context.parent === FlexLayoutTypes.NONE) {
-    console.warn(
-      'A `flex-layout.col` block is being inserted directly into the page, but it needs to be inserted into a `flex-layout.row` block.'
-    )
     return null
   }
 

--- a/react/FlexLayout.tsx
+++ b/react/FlexLayout.tsx
@@ -26,12 +26,6 @@ const FlexLayout: StorefrontFunctionComponent<Props> = props => {
 
   const isTopLevel = context.parent === FlexLayoutTypes.NONE
 
-  if (fullWidth && !isTopLevel) {
-    console.warn(
-      'Prop `fullWidth` is allowed only on top-level `flex-layout.row` blocks.'
-    )
-  }
-
   if (fullWidth || !isTopLevel) {
     return <div className={handles.flexRow}>{content}</div>
   }

--- a/react/Row.tsx
+++ b/react/Row.tsx
@@ -111,12 +111,6 @@ const Row: StorefrontFunctionComponent<Props> = ({
     hideEmptyCols: experimentalHideEmptyCols,
   })
 
-  if (context.parent === FlexLayoutTypes.ROW) {
-    console.warn(
-      'A flex-row is being inserted directly into another flex-row. This might have unpredicted behaviour.'
-    )
-  }
-
   const isSizingAuto = colSizing === ColSizing.auto
 
   const justifyToken =

--- a/react/hooks/responsiveWidth.ts
+++ b/react/hooks/responsiveWidth.ts
@@ -46,9 +46,6 @@ const distributeAvailableWidth = (
   )
 
   if (availableWidth < 0 && !hasAnyWidthGrow) {
-    console.warn(
-      'Total width set for columns of a flex-layout.row block exceeds 100%.'
-    )
     const normalization = -(100 / availableWidth)
     cols = cols.map(col => ({
       ...col,


### PR DESCRIPTION
#### What problem is this solving?
Removes warnings that were not very useful, and brought down perf if they were being intercepted.

Workspace: https://lbebber--carrefourbr.myvtex.com/

Before:
<img width="45" alt="Screen Shot 2020-08-28 at 17 15 57" src="https://user-images.githubusercontent.com/5691711/91612000-dc401a00-e952-11ea-9755-a1a88930030d.png">

After:
<img width="51" alt="Screen Shot 2020-08-28 at 17 18 50" src="https://user-images.githubusercontent.com/5691711/91612021-e235fb00-e952-11ea-95c2-697ece73570f.png">


<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
