### PR TITLE
Add html id on flexRow from Site Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- New prop `"htmlId"` that adds an html id on `flexRow` and it can be changed from Site Editor. This enables the possibility to access a section from page using links.
 
 ## [0.19.0] - 2021-09-24
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ The props below support [`responsive-values`](https://github.com/vtex-apps/respo
 | `preventHorizontalStretch` | `Boolean`                         | Prevents the row from stretching horizontally to fill its parent width.                                                 | `false`       |
 | `preventVerticalStretch`   | `Boolean`                         | Prevents the row from stretching vertically to fill its parent height with `items-stretch` token.                       | `false`       |
 | `rowGap`                   | `0...10`                          | A `number` or `string` magnitude for the `pb` Tachyons token to be applied to columns inside of the `flex-layout.row`.  | `undefined`   |
-
+| `htmlId`                   | `String`                          | This prop adds an html id on `flexRow` and it can be changed from Site Editor. This enables the possibility to access a section from page using links.                                                                                | `undefined`   |
 ### `flex-layout.col`
 
 | Prop name                | Type                              | Description                                                                                                                | Default value |

--- a/react/FlexLayout.tsx
+++ b/react/FlexLayout.tsx
@@ -18,7 +18,7 @@ const CSS_HANDLES = ['flexRow'] as const
 
 const FlexLayout: StorefrontFunctionComponent<Props> = props => {
   const responsiveProps = useResponsiveValues(props) as Props
-  const { fullWidth } = responsiveProps
+  const { fullWidth, htmlId } = responsiveProps
   const context = useFlexLayoutContext()
   const handles = useCssHandles(CSS_HANDLES)
 
@@ -27,11 +27,15 @@ const FlexLayout: StorefrontFunctionComponent<Props> = props => {
   const isTopLevel = context.parent === FlexLayoutTypes.NONE
 
   if (fullWidth || !isTopLevel) {
-    return <div className={handles.flexRow}>{content}</div>
+    return (
+      <div className={handles.flexRow} id={htmlId}>
+        {content}
+      </div>
+    )
   }
 
   return (
-    <div className={handles.flexRow}>
+    <div className={handles.flexRow} id={htmlId}>
       <Container>{content}</Container>
     </div>
   )
@@ -51,6 +55,15 @@ const messages = defineMessages({
 FlexLayout.schema = {
   title: messages.title.id,
   description: messages.description.id,
+  type: 'object',
+  properties: {
+    htmlId: {
+      title: 'Html Id',
+      description: 'HTML Id Attribute of flexRow',
+      type: 'string',
+      default: null,
+    },
+  },
 }
 
 export default FlexLayout

--- a/react/Row.tsx
+++ b/react/Row.tsx
@@ -55,6 +55,7 @@ export interface Props extends Flex, Gap, Border {
   horizontalAlign?: ColJustify
   colJustify?: ColJustify
   experimentalHideEmptyCols?: boolean
+  htmlId?: string
 }
 
 const Row: StorefrontFunctionComponent<Props> = ({

--- a/react/package.json
+++ b/react/package.json
@@ -16,7 +16,7 @@
     "eslint-config-vtex-react": "^5.0.1",
     "prettier": "^1.18.2",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "resolutions": {
     "@types/graphql": "14.0.7"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5168,10 +5168,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typescript@^3.3.3333:
   version "3.6.3"


### PR DESCRIPTION
#### What problem is this solving?

This feature enables us to add html ids from Site Editor on page sections that use `flex-layout` as a container so we can navigate to this sections using menu links. This helps in the situations when we create Landing Pages dynamically from Site Editor and we need to navigate to different sections.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://htmlid--iviteb.myvtex.com/)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/77269087/175025653-e5c63a77-2947-4eb1-bc11-f45addf7d3f2.png)
![image](https://user-images.githubusercontent.com/77269087/175026575-c510cd9f-ca9c-4086-933d-40b73f5bbb2e.png)


<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/fLnGPP2IQWtGriJDUO/giphy.gif)
