### PR TITLE
Add tablet as responsive width

### DIFF
--- a/react/hooks/responsiveWidth.ts
+++ b/react/hooks/responsiveWidth.ts
@@ -81,6 +81,7 @@ export const useResponsiveWidth = (
   const { device } = useDevice()
 
   const isPhone = device === 'phone'
+  const isTablet = device === 'tablet'
 
   const { preserveLayoutOnMobile = false, hideEmptyCols = false } =
     options || {}
@@ -102,7 +103,7 @@ export const useResponsiveWidth = (
     if (width && typeof width === 'object') {
       return {
         element: col,
-        width: isPhone ? width.mobile || 0 : width.desktop || 0,
+        width: isPhone ? width.mobile || 0 : isTablet ? width.tablet || 0 : width.desktop || 0,
         hasDefinedWidth: true,
         isResponsive: true,
       }

--- a/react/hooks/responsiveWidth.ts
+++ b/react/hooks/responsiveWidth.ts
@@ -103,7 +103,7 @@ export const useResponsiveWidth = (
     if (width && typeof width === 'object') {
       return {
         element: col,
-        width: isPhone ? width.mobile || 0 : isTablet ? width.tablet || 0 : width.desktop || 0,
+        width: isPhone ? width.phone || 0 : isTablet ? width.tablet || 0 : width.desktop || 0,
         hasDefinedWidth: true,
         isResponsive: true,
       }

--- a/react/modules/valuesParser.ts
+++ b/react/modules/valuesParser.ts
@@ -5,6 +5,7 @@ type Group<T, U> = { [key in keyof T]: U }
 type TachyonsInputGroup<T> = Group<T, TachyonsScaleInput>
 interface ResponsiveInput<T> {
   mobile: T
+  phone: T
   tablet: T
   desktop: T
 }
@@ -22,10 +23,11 @@ const isResponsiveInput = <T>(value: any): value is ResponsiveInput<T> =>
  */
 export const parseResponsive = <T, U>(parse: (value: T) => U) => (
   value: T | ResponsiveInput<T>
-): null | U | { mobile: U; tablet: U; desktop: U } => {
+): null | U | { mobile: U; phone: U; tablet: U; desktop: U } => {
   if (isResponsiveInput(value)) {
     return {
       mobile: parse(value.mobile),
+      phone: parse(value.phone),
       tablet: parse(value.tablet),
       desktop: parse(value.desktop),
     }

--- a/react/modules/valuesParser.ts
+++ b/react/modules/valuesParser.ts
@@ -5,6 +5,7 @@ type Group<T, U> = { [key in keyof T]: U }
 type TachyonsInputGroup<T> = Group<T, TachyonsScaleInput>
 interface ResponsiveInput<T> {
   mobile: T
+  tablet: T
   desktop: T
 }
 
@@ -21,10 +22,11 @@ const isResponsiveInput = <T>(value: any): value is ResponsiveInput<T> =>
  */
 export const parseResponsive = <T, U>(parse: (value: T) => U) => (
   value: T | ResponsiveInput<T>
-): null | U | { mobile: U; desktop: U } => {
+): null | U | { mobile: U; tablet: U; desktop: U } => {
   if (isResponsiveInput(value)) {
     return {
       mobile: parse(value.mobile),
+      tablet: parse(value.tablet),
       desktop: parse(value.desktop),
     }
   }


### PR DESCRIPTION
#### What problem is this solving?

Allow usage of both `phone` and `tablet` widths for `flex-layout.col`.

#### How to test it?

Use below code:
```
{
  "store.home": {
    "blocks": [
      "flex-layout.row#responsive-tablet"
    ]
  },

  "flex-layout.row#responsive-tablet": {
    "children": [
      "flex-layout.col#left-column",
      "flex-layout.col#right-column"
    ]
  },

  "flex-layout.col#left-column": {
    "props": {
      "width": {
        "desktop": "33%",
        "phone": "55%"
      }
    },
    "children": ["rich-text#left-text"]
  },
  "flex-layout.col#right-column": {
    "children": ["rich-text#right-text"]
  },

  "rich-text#left-text": {
    "props": {
      "text": "## This column should adjust its width under 640px, between 641px and 1025px and above 1026px"
    }
  },
  "rich-text#right-text": {
    "props": {
      "text": "## This column doesn't need the `width` object declared"
    }
  }
}

```

#### Screenshots or example usage:

N/A

#### Describe alternatives you've considered, if any.

Most common layout shifts need to take place between desktop and tablet. The transition from tablet to mobile is mostly handled when `preserveLayoutOnMobile` is set to `false`.

#### Related to / Depends on

N/A

#### How does this PR make you feel? [:link:](http://giphy.com/)

N/A :)
