### PR TITLE
Removes properties from schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove properties from schema since it cannot be edited through site editor.
 
 ## [0.21.2] - 2023-04-25
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ The props below support [`responsive-values`](https://github.com/vtex-apps/respo
 | `preventHorizontalStretch` | `Boolean`                                                      | Prevents the row from stretching horizontally to fill its parent's width.                                                                                                                                                     | `false`       |
 | `preventVerticalStretch`   | `Boolean`                                                      | Prevents the row from stretching vertically to fill its parent's height with the `items-stretch` token.                                                                                                                       | `false`       |
 | `rowGap`                   | `0...10`                                                       | A `number` or `string` magnitude for applying the `pb` Tachyons token to columns in the `flex-layout.row`.                                                                                                                    | `undefined`   |
-| `htmlId`                   | `String`                                                       | This prop adds an HTML id to `flexRow`, and it can be changed from Site Editor. This allows accessing a page section using links.                                                                                             | `undefined`   |
+| `htmlId`                   | `String`                                                       | This prop adds an HTML id to `flexRow`. This allows accessing a page section using links.                                                                                             | `undefined`   |
 
 ### `flex-layout.col`
 

--- a/react/FlexLayout.tsx
+++ b/react/FlexLayout.tsx
@@ -55,14 +55,6 @@ const messages = defineMessages({
 FlexLayout.schema = {
   title: messages.title.id,
   description: messages.description.id,
-  properties: {
-    htmlId: {
-      title: 'Html Id',
-      description: 'HTML Id Attribute of flexRow',
-      type: 'string',
-      default: null,
-    },
-  },
 }
 
 export default FlexLayout


### PR DESCRIPTION
#### What problem is this solving?
Since #62, editing the site editor's HTML id property is prohibited. This PR removes it from the schema to avoid confusion.